### PR TITLE
Move common settings to a client util

### DIFF
--- a/pkg/table_descriptor.go
+++ b/pkg/table_descriptor.go
@@ -3,13 +3,10 @@ package pkg
 import (
 	"context"
 	"strconv"
-	"time"
 
-	"github.com/imroc/req/v3"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
-	"gopkg.in/yaml.v2"
 )
 
 type CortexDescriptorsResponse struct {
@@ -48,20 +45,14 @@ func tableCortexDescriptor() *plugin.Table {
 func listDescriptors(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	config := GetConfig(d.Connection)
+	client := CortexHTTPClient(ctx, config)
 
 	var response CortexDescriptorsResponse
 	var page int = 0
 	for {
 		logger.Debug("listDescriptors", "page", page)
-		err := req.C().
-			SetJsonUnmarshal(yaml.Unmarshal).
-			SetBaseURL(*config.BaseURL).
+		err := client.
 			Get("/api/v1/catalog/descriptors").
-			// Backoff and Retry
-			SetRetryCount(2).
-			SetRetryBackoffInterval(time.Second, 5*time.Second).
-			// Authentication
-			SetBearerAuthToken(*config.ApiKey).
 			// Options
 			SetQueryParam("yaml", "false").
 			// Pagination

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -2,10 +2,24 @@ package pkg
 
 import (
 	"context"
+	"time"
 
+	"github.com/imroc/req/v3"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"gopkg.in/yaml.v2"
 )
+
+// Create a req http client for the Cortex API.
+// This will set the BaseURL and Auth from config, as well as common retry settings.
+func CortexHTTPClient(ctx context.Context, config *SteampipeConfig) *req.Client {
+	return req.C().
+		SetBaseURL(*config.BaseURL).
+		SetJsonUnmarshal(yaml.Unmarshal).
+		SetCommonRetryCount(2).
+		SetCommonRetryBackoffInterval(time.Second, 5*time.Second).
+		SetCommonBearerAuthToken(*config.ApiKey)
+}
 
 // Get field from the data and for each item of type T, get the nested field "child"
 // always returns a string array


### PR DESCRIPTION
# Summary

Add `CortexHTTPClient` util which creates a common req.C() with retry, auth, baseurl, and yaml parsing.