### PR TITLE
Update to yaml.v3 to fix map[interface{}]interface{} issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.4
 require (
 	github.com/turbot/go-kit v0.10.0-rc.0
 	github.com/turbot/steampipe-plugin-sdk/v5 v5.10.1
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -114,6 +114,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 require (

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/imroc/req/v3"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Create a req http client for the Cortex API.


### PR DESCRIPTION
# Summary

Was seeing this issue:
```
Error: cortex_sandbox: metadata: json: unsupported type: map[interface {}]interface {}  (SQLSTATE HV000)   
```

However looks to be a yaml.v2 bug.
