### PR TITLE
Add owner_teams and owner_individuals to cortex_entity table

### DIFF
--- a/docs/tables/entity.md
+++ b/docs/tables/entity.md
@@ -18,6 +18,8 @@ see the descriptor (yaml definition) of an entity use the `descriptor` table.
 |`archived`|Is archived.|
 |`repository`|Git repo full name|
 |`slack_channels`|List of string slack channels|
+|`owner_teams`|List of owning team tags|
+|`owner_individuals`|List of owning individuals emails|
 
 ## Examples
 

--- a/pkg/table_entity.go
+++ b/pkg/table_entity.go
@@ -51,7 +51,7 @@ type CortexEntityElement struct {
 	Archived    bool                          `yaml:"isArchived"`
 	Git         CortexGithub                  `yaml:"git"`
 	Slack       []CortexSlackChannel          `yaml:"slackChannels"`
-	// Members TODO
+	Owners      CortexEntityOwners            `yaml:"owners"`
 }
 
 type CortexEntityElementHierarchy struct {
@@ -61,6 +61,19 @@ type CortexEntityElementHierarchy struct {
 type CortexEntityElementMetadata struct {
 	Key   string      `yaml:"key"`
 	Value ScalarOrMap `yaml:"value"`
+}
+
+type CortexEntityOwners struct {
+	Teams       []CortexEntityOwnersTeam       `yaml:"teams"`
+	Individuals []CortexEntityOwnersIndividual `yaml:"individuals"`
+}
+
+type CortexEntityOwnersTeam struct {
+	Tag string `yaml:"tag"`
+}
+
+type CortexEntityOwnersIndividual struct {
+	Email string `yaml:"email"`
 }
 
 func tableCortexEntity() *plugin.Table {
@@ -87,6 +100,8 @@ func tableCortexEntity() *plugin.Table {
 			{Name: "archived", Type: proto.ColumnType_BOOL, Description: "Is archived."},
 			{Name: "repository", Type: proto.ColumnType_STRING, Description: "Git repo full name", Transform: transform.FromField("Git.Repository")},
 			{Name: "slack_channels", Type: proto.ColumnType_JSON, Description: "List of string slack channels"},
+			{Name: "owner_teams", Type: proto.ColumnType_JSON, Description: "List of owning team tags", Transform: FromStructSlice[CortexEntityOwnersTeam]("Owners.Teams", "Tag")},
+			{Name: "owner_individuals", Type: proto.ColumnType_JSON, Description: "List of owning individuals emails", Transform: FromStructSlice[CortexEntityOwnersIndividual]("Owners.Individuals", "Email")},
 		},
 	}
 }


### PR DESCRIPTION
# Summary

Add two new columns to the `cortex_entity` table.

These lists owning teams and individuals.

Teams can be joined on the `cortex_teams` table.