### PR TITLE
Rename pkg to cortex

### DIFF
--- a/cortex/models.go
+++ b/cortex/models.go
@@ -1,4 +1,4 @@
-package pkg
+package cortex
 
 type Cortex struct {
 	Openapi string     `yaml:"openapi"`

--- a/cortex/steampipe.go
+++ b/cortex/steampipe.go
@@ -1,4 +1,4 @@
-package pkg
+package cortex
 
 import (
 	"context"
@@ -41,7 +41,7 @@ func GetConfig(connection *plugin.Connection) *SteampipeConfig {
 	return &config
 }
 
-func SteampipePlugin(ctx context.Context) *plugin.Plugin {
+func Plugin(ctx context.Context) *plugin.Plugin {
 	p := &plugin.Plugin{
 		Name:             "steampipe-plugin-cortex",
 		DefaultTransform: transform.FromGo().NullIfZero(),

--- a/cortex/table_descriptor.go
+++ b/cortex/table_descriptor.go
@@ -1,4 +1,4 @@
-package pkg
+package cortex
 
 import (
 	"context"

--- a/cortex/table_entity.go
+++ b/cortex/table_entity.go
@@ -1,4 +1,4 @@
-package pkg
+package cortex
 
 import (
 	"context"

--- a/cortex/table_scorecard_score.go
+++ b/cortex/table_scorecard_score.go
@@ -1,4 +1,4 @@
-package pkg
+package cortex
 
 import (
 	"context"

--- a/cortex/table_team.go
+++ b/cortex/table_team.go
@@ -1,4 +1,4 @@
-package pkg
+package cortex
 
 import (
 	"context"

--- a/cortex/utils.go
+++ b/cortex/utils.go
@@ -1,4 +1,4 @@
-package pkg
+package cortex
 
 import (
 	"context"

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/smirl/steampipe-plugin-cortex/pkg"
+	"github.com/smirl/steampipe-plugin-cortex/cortex"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{PluginFunc: pkg.SteampipePlugin})
+	plugin.Serve(&plugin.ServeOpts{PluginFunc: cortex.Plugin})
 }


### PR DESCRIPTION
# Summary

- Renames `pkg` to `cortex` as per #11 
- Also renames the `SteampipePlugin` function to `Plugin`
