### PR TITLE
Update docs with better formatting and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,7 @@ drive action to continuously improve software.
 For example:
 
 ```sql
-select
-    "name",
-    "tag",
-    "description",
-    "type",
-    "parents",
-    "groups",
-    "metadata",
-    "last_updated",
-    "links",
-    "archived",
-    "repository",
-    "slack_channels"
-from
-    cortex_entity
-limit 10
+select * from cortex_entity limit 10
 ```
 
 ## Documentation
@@ -37,7 +22,7 @@ limit 10
 
 ### Install
 
-Download and install the latest AWS plugin:
+Download and install the latest:
 
 ```bash
 steampipe plugin install smirl/cortex
@@ -72,3 +57,7 @@ connection "cortex" {
     # base_url = "https://app.cortex.mycompany.com"
 }
 ```
+
+## Get Involved
+
+Open source: https://github.com/smirl/steampipe-plugin-cortex

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-organization: Cortex
+organization: smirl
 category: ["software development"]
 icon_url: "/images/plugins/smirl/cortex.svg"
 brand_color: "#25074d"
@@ -36,7 +36,7 @@ select * from cortex_entity limit 10
 
 ### Install
 
-Download and install the latest AWS plugin:
+Download and install the latest:
 
 ```bash
 steampipe plugin install smirl/cortex
@@ -71,3 +71,7 @@ connection "cortex" {
     # base_url = "https://app.cortex.mycompany.com"
 }
 ```
+
+## Get Involved
+
+Open source: https://github.com/smirl/steampipe-plugin-cortex

--- a/docs/tables/descriptor.md
+++ b/docs/tables/descriptor.md
@@ -4,28 +4,23 @@ This table calls the List entity descriptors API to get the data about each
 entity descriptor (yaml definition). To see information about the entity from
 all sources use the `entity` table.
 
-
-|Field|Description|
-|----|-----|
-|`tag`|The x-cortex-tag of the entity|
-|`title`|Title|
-|`description`|Description|
-|`type`|Entity Type|
-|`parents`|Parent tags.|
-|`groups`|Groups, kind of like tags|
-|`team`|Raw team|
-|`owners`|Raw owner|
-|`slack`|Raw slack|
-|`links`|List of links|
-|`metadata`|Raw custom metadata|
-|`repository`|Git repo full name|
-|`victorops`|Victorops team slug|
-|`jira`|List of jira projects|
-
 ## Examples
 
 ### Get information about a single entity descriptor
 
 ```sql
-select * from cortex_descriptor where tag = 'my-service'
+select
+  *
+from
+  cortex_descriptor
+where
+  tag = 'service1'
+```
+
+```
++----------+----------+-----------------------------+---------+---------------+------------+--------+--------+-------------------------------------------------------------------------------------------------------+--------+--------------------------------------------------------------+
+| tag      | title    | description                 | type    | parents       | groups     | team   | owners | slack                                                                                                 | links  | metadata         | repository   | victorops       | jira     | 
++----------+----------+-----------------------------+---------+---------------+------------+--------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| service1 | Service1 | Test service for kubernetes | service | ["my-domain"] | ["groupa"] | <null> | <null> | {"Channels":[{"Description":"Slack Channel","Name":"service1-support","NotificationsEnabled":false}]} | <null> | {"key": "value"} | org/service1 | victorops-team1 | ["JIRA"] |
++----------+----------+-----------------------------+---------+---------------+------------+--------+--------+-------------------------------------------------------------------------------------------------------+--------+--------------------------------------------------------------+
 ```

--- a/docs/tables/entity.md
+++ b/docs/tables/entity.md
@@ -3,39 +3,69 @@
 This table calls the "List entities" API to get the data about each entity. To
 see the descriptor (yaml definition) of an entity use the `descriptor` table.
 
-
-|Field|Description|
-|----|-----|
-|`name`|Pretty name of the entity.|
-|`tag`|The x-cortex-tag of the entity.|
-|`description`|Description.|
-|`type`|Entity Type.|
-|`parents`|Parents of the entity.|
-|`groups`|Groups, kind of like tags.|
-|`metadata`|Raw custom metadata|
-|`last_updated`|Last updated time.|
-|`links`|List of links|
-|`archived`|Is archived.|
-|`repository`|Git repo full name|
-|`slack_channels`|List of string slack channels|
-|`owner_teams`|List of owning team tags|
-|`owner_individuals`|List of owning individuals emails|
-
 ## Examples
 
 ### Get information about a single entity
 
 ```sql
-select * from cortex_entity where tag = 'my-service'
+select
+  *
+from
+  cortex_entity
+where
+  tag = 'service1'
+```
+
+```
++----------+----------+-----------------------------+---------+----------------------+-----------------+-----------------+---------------------------+--------------------------+----------+--------------+----------------+----------------+-------------------+
+| name     | tag      | description                 | type    | parents              | groups          | metadata        | last_updated              | links                    | archived | repository   | slack_channels | owner_teams    | owner_individuals |
++----------+----------+-----------------------------+---------+----------------------+-----------------+-----------------+---------------------------+--------------------------+----------+--------------+----------------+----------------+-------------------+
+| service1 | service1 | Test service for kubernetes | service | ["service1-project"] | ["third-party"] | {"key":"value"} | 2024-09-06T18:26:10+08:00 | ["https://example.com/"] | false    | k8s/service1 | <null>         | ["my-squad"]   | <null>            |
++----------+----------+-----------------------------+---------+----------------------+-----------------+-----------------+---------------------------+--------------------------+----------+--------------+----------------+----------------+-------------------+
 ```
 
 ### Count of all domains
 
 ```sql
-select count(*) from cortex_entity where type = 'domain'
+select
+  count(*)
+from
+  cortex_entity
+where
+  type = 'domain'
+```
+
+```
++-------+
+| count |
++-------+
+| 1856  |
++-------+
 ```
 
 ### Extract custom metadata into a column
 
 ```sql
-select tag, metadata -> 'my_key' as my_key from cortex_entity limit 10
+select
+  tag,
+  metadata -> 'my_key' as my_key
+from
+  cortex_entity limit 10
+```
+
+```
++---------------------------+---------+
+| tag                       | my_key  |
++---------------------------+---------+
+| alpha-service             | value1  |
+| beta-service              | value2  |
+| gamma-service             | value3  |
+| delta-service             | value4  |
+| epsilon-service           | value5  |
+| zeta-service              | value6  |
+| eta-service               | value7  |
+| theta-service             | value8  |
+| iota-service              | value9  |
+| kappa-service             | value10 |
++---------------------------+---------+
+```

--- a/docs/tables/scorecard_score.md
+++ b/docs/tables/scorecard_score.md
@@ -3,36 +3,12 @@
 ## Description
 Description of the Scorecard Scores table.
 
-## Columns
-- **scorecard_tag**: Scorecard tag. This is a required field.
-- **scorecard_name**: Scorecard name.
-- **service_tag**: Service type.
-- **service_name**: Service name.
-- **service_groups**: Service groups.
-- **last_evaluated**: Last evaluated.
-- **rule_identifier**: Rule identifier.
-- **rule_title**: Rule title.
-- **rule_description**: Rule description.
-- **rule_expression**: Rule expression.
-- **rule_effective_from**: Rule effective from.
-- **rule_level_name**: Rule level name.
-- **rule_level_number**: Rule level number.
-- **rule_weight**: Rule weight.
-- **rule_score**: Rule score.
-- **rule_pass**: Rule pass.
-
-## Example
-| scorecard_name | scorecard_tag | service_name | service_tag | service_groups | last_evaluated                 | rule_identifier                      | rule_title | rule_description | rule_expression | rule_effective_from | rule_level_name | rule_level_number | rule_weight | rule_score | rule_pass |
-|----------------|---------------|--------------|-------------|----------------|--------------------------------|--------------------------------------|------------|------------------|-----------------|---------------------|-----------------|-------------------|-------------|------------|-----------|
-| My Scorecard   | my-scorecard  | Service      | service-1   | ["group"]      | 2024-09-05T16:57:00.100076     | c3b01120-dd3d-4978-af2d-28d5ef8249ae | Title1     | Description1     | Expression1     |                     | Gold            | 3                 | 10          | 10         | true      |
-| My Scorecard   | my-scorecard  | Service      | service-1   | ["group"]      | 2024-09-05T16:57:00.100076     | e594520d-61f2-4715-b6cb-7c0c04eeba8f | Title2     | Description2     | Expression2     |                     | Silver          | 2                 | 20          | 0          | false     |
-
 ## SQL Examples
 
 ### Query scores for a specific scorecard
 
 ```sql
-  SELECT
+select
   scorecard_tag,
   scorecard_name,
   service_tag,
@@ -48,37 +24,60 @@ Description of the Scorecard Scores table.
   rule_level_number,
   rule_weight,
   rule_score,
-  rule_pass
-FROM
-  cortex_scorecard_scores
-WHERE
-  scorecard_tag = 'my-scorecard';
+  rule_pass 
+from
+  cortex_scorecard_score
+where
+  scorecard_tag = 'my-scorecard'
+limit 10
+```
+
+```
++-------------------+-------------------+-------------------+-------------------+---------------------+----------------------------+--------------------------------------+------------------------------------------------+-------------------------------------------------+-----------------+-------------------+-------------+------------+-----------+
+| scorecard_tag     | scorecard_name    | service_tag       | service_name      | service_groups      | last_evaluated             | rule_identifier                      | rule_title                                     | rule_expression                                 | rule_level_name | rule_level_number | rule_weight | rule_score | rule_pass |
++-------------------+-------------------+-------------------+-------------------+---------------------+----------------------------+--------------------------------------+------------------------------------------------+-------------------------------------------------+-----------------+-------------------+-------------+------------+-----------+
+| service-readiness | Cortex Onboarding | service-1         | service-1         | ["microservice"]    | 2025-02-12T21:09:18.246024 | c536b79c-f35e-3e47-833f-194df4860f77 | Updated by Github App                          | custom("updated-by") != null                    | Bronze          | 1                 | 1           | 1          | true      |
+| service-readiness | Cortex Onboarding | service-1         | service-1         | ["microservice"]    | 2025-02-12T21:09:18.246024 | 92ab2234-ffb1-371b-9488-8ebe3485e503 | Has owners                                     | ownership.allOwners().length > 0                | Bronze          | 1                 | 5           | 5          | true      |
+| service-readiness | Cortex Onboarding | service-2         | service-2         | ["component"]       | 2025-02-12T14:59:52.951055 | 92ab2234-ffb1-371b-9488-8ebe3485e503 | Has owners                                     | ownership.allOwners().length > 0                | Bronze          | 1                 | 5           | 5          | true      |
+| service-readiness | Cortex Onboarding | service-3         | service-3         | ["third-party"]     | 2025-02-12T22:15:00.232289 | e423f153-809f-3279-ac30-4ee48aa8ca95 | soxScope field set in catalog.yml              | custom("sox-scope") != "undefined"              | Gold            | 3                 | 1           | 1          | true      |
+| service-readiness | Cortex Onboarding | service-1         | service-1         | ["microservice"]    | 2025-02-12T21:09:18.246024 | e423f153-809f-3279-ac30-4ee48aa8ca95 | soxScope field set in catalog.yml              | custom("sox-scope") != "undefined"              | Gold            | 3                 | 1           | 1          | true      |
+| service-readiness | Cortex Onboarding | service-1         | service-1         | ["microservice"]    | 2025-02-12T21:09:18.246024 | 2a235b74-711b-396a-a8da-994e437b5ee8 | personalDataHandling field set in catalog.yml  | custom("personal-data-handling") != "undefined" | Gold            | 3                 | 1           | 1          | true      |
+| service-readiness | Cortex Onboarding | service-1         | service-1         | ["microservice"]    | 2025-02-12T21:09:18.246024 | 60e0fa9e-bc63-3f25-9a08-0e50b271494b | paymentProcessing field set in catalog.yml     | custom("payment-processing") != "undefined"     | Gold            | 3                 | 1           | 1          | true      |
+| service-readiness | Cortex Onboarding | service-2         | service-2         | ["component"]       | 2025-02-12T14:59:52.951055 | 945e4ff1-f775-3f3b-8b66-7199e1a595ab | Has description                                | entity.description() != null                    | Bronze          | 1                 | 1           | 1          | true      |
+| service-readiness | Cortex Onboarding | service-4         | service-4         | ["lambda-function"] | 2025-02-13T04:37:38.739684 | c536b79c-f35e-3e47-833f-194df4860f77 | Updated by Github App                          | custom("updated-by") != null                    | Bronze          | 1                 | 1           | 1          | true      |
+| service-readiness | Cortex Onboarding | service-5         | service-5         | ["other"]           | 2025-02-12T21:41:45.857825 | 945e4ff1-f775-3f3b-8b66-7199e1a595ab | Has description                                | entity.description() != null                    | Bronze          | 1                 | 1           | 1          | true      |
++-------------------+-------------------+-------------------+-------------------+---------------------+----------------------------+--------------------------------------+------------------------------------------------+-------------------------------------------------+-----------------+-------------------+-------------+------------+-----------+
 ```
 
 # Query scores where the rule passed
 
 ```sql
-  SELECT
-  scorecard_tag,
-  scorecard_name,
+select
   service_tag,
-  service_name,
-  service_groups,
-  last_evaluated,
-  rule_identifier,
-  rule_title,
-  rule_description,
-  rule_expression,
-  rule_effective_from,
-  rule_level_name,
-  rule_level_number,
-  rule_weight,
-  rule_score,
-  rule_pass
-FROM
+  rule_expression
+from
   cortex_scorecard_scores
-WHERE
-  scorecard_tag = 'my-scorecard' and rule_pass = true
-ORDER BY
-    rule_level_number;
+where
+  scorecard_tag = 'my-scorecard' 
+  and rule_pass = true 
+order by
+  rule_level_number
+limit 10
+```
+
+```
++-------------------+------------------------------------------------------------+
+| service_tag       | rule_expression                                            |
++-------------------+------------------------------------------------------------+
+| service-1         | git != null                                                |
+| service-1         | git.fileExists("README.md") or git.fileExists("readme.md") |
+| service-1         | ownership.allOwners().length > 0                           |
+| service-2         | custom("updated-by") != null                               |
+| service-2         | entity.description() != null                               |
+| service-2         | git != null                                                |
+| service-2         | ownership.allOwners().length > 0                           |
+| service-3         | custom("updated-by") != null                               |
+| service-3         | entity.description() != null                               |
+| service-3         | git != null                                                |
++-------------------+------------------------------------------------------------+
 ```

--- a/docs/tables/team.md
+++ b/docs/tables/team.md
@@ -2,49 +2,68 @@
 
 This table calls the List team API to get the data about each team. 
 
-
-|Field|Description|
-|----|-----|
-|`name`|Pretty name of the team.|
-|`tag`|The teamTag of the team.|
-|`metadata`|Raw custom metadata|
-|`links`|List of links|
-|`archived`|Is archived.|
-|`slack_channels`|List of string slack channels|
-|`members`|List of team members|
-
-
 ## Examples
 
 ### Get information about a team
 
 ```sql
-select 
-    name,
-    tag,
-    metadata,
-    links,
-    archived,
-    slack_channels,
-    members
-from cortex_team
-where tag = 'my-team'
+select
+  name,
+  tag,
+  metadata,
+  links,
+  archived,
+  slack_channels,
+  members 
+from
+  cortex_team 
+where
+  tag = 'my-team'
+```
+
+```
++-------------+-------------+----------------------------------------------------------+-------------------------------+----------+----------------+-----------------------------------------------------------------------------------------------+
+| name        | tag         | metadata                                                 | links                         | archived | slack_channels | members                                                                                       |
++-------------+-------------+----------------------------------------------------------+-------------------------------+----------+----------------+-----------------------------------------------------------------------------------------------+
+| Alpha Squad | alpha-squad | {"description":null,"name":"Alpha Squad","summary":null} | ["https://example.com/alpha"] | false    | <null>         | [{"Email":"joe.blogs@example.com","Name":"Joe Blogs","NotificationsEnabled":false,"Role":""}] |
++-------------+-------------+----------------------------------------------------------+-------------------------------+----------+----------------+-----------------------------------------------------------------------------------------------+
 ```
 
 ### List teams for each member and the count of teams they are members of
 
 ```sql
 select
-    email,
-    array_agg(tag) as teams,
-    count(tag) as team_count
-from (
+  email,
+  array_agg(tag) as teams,
+  count(tag) as team_count 
+from
+  (
     select
-        tag,
-        lower(jsonb_array_elements(members) ->> 'Email') as email
+      tag,
+      lower(jsonb_array_elements(members) ->> 'Email') as email 
     from
-        cortex_team
-) as t
-group by t.email
-order by squad_count desc
+      cortex_team 
+  )
+  as t 
+group by
+  t.email 
+order by
+  team_count desc limit 10
+```
+
+```
++---------------------------+-----------------------------------------------------------------------------------+------------+
+| email                     | teams                                                                             | team_count |
++---------------------------+-----------------------------------------------------------------------------------+------------+
+| john.doe@example.com      | alpha-squad,beta-squad,gamma-squad,delta-squad,epsilon-squad,zeta-squad,eta-squad | 7          |
+| jane.smith@example.com    | theta-squad,iota-squad,kappa-squad,lambda-squad,mu-squad,nu-squad                 | 6          |
+| alice.jones@example.com   | xi-squad,omicron-squad,pi-squad,rho-squad,sigma-squad,tau-squad                   | 6          |
+| bob.brown@example.com     | upsilon-squad,phi-squad,chi-squad,psi-squad,omega-squad                           | 5          |
+| charlie.davis@example.com | alpha-squad,beta-squad,gamma-squad,delta-squad                                    | 4          |
+| diana.evans@example.com   | epsilon-squad,zeta-squad,eta-squad,theta-squad                                    | 4          |
+| emily.frank@example.com   | iota-squad,kappa-squad,lambda-squad                                               | 3          |
+| frank.green@example.com   | mu-squad,nu-squad,xi-squad                                                        | 3          |
+| grace.hill@example.com    | omicron-squad,pi-squad,rho-squad                                                  | 3          |
+| hank.ivan@example.com     | sigma-squad,tau-squad,upsilon-squad                                               | 3          |
++---------------------------+-----------------------------------------------------------------------------------+------------+
 ```


### PR DESCRIPTION
# Summary

Apply feedback on docs from #11 

> - All the queries should be formatted per https://www.freeformatter.com/sql-formatter.html. They should use 2 spaces per indent level.
> - Could you please update the README and docs/index.md files per https://hub.steampipe.io/plugins/francois2metz/gandi?
>   - This update should include query outputs
>   - References to AWS should be removed
>   - References to the usage of env variables should be mentioned
>   - Please include the ## Get Involved section as well
>   - In the docs/index.md file, please update the organization metadata to use smirl instead of Cortex.