### PR TITLE
Upate brand color and example query

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ drive action to continuously improve software.
 For example:
 
 ```sql
-select * from cortex_entity limit 10
+select tag, owner_teams, metadata -> 'custom_field' from cortex_entity limit 10
 ```
 
 ## Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 organization: smirl
 category: ["software development"]
 icon_url: "/images/plugins/smirl/cortex.svg"
-brand_color: "#25074d"
+brand_color: "#653ee8"
 display_name: "Cortex"
 short_name: "cortex"
 description: "Steampipe plugin for Cortex developer portal."
@@ -25,7 +25,7 @@ drive action to continuously improve software.
 For example:
 
 ```sql
-select * from cortex_entity limit 10
+select tag, owner_teams, metadata -> 'custom_field' from cortex_entity limit 10
 ```
 
 ## Documentation


### PR DESCRIPTION
# Summary

From Ved:

- I think the brand color of the plugin should be #7047eb .
- Could you please define few columns instead of * in the display query of the plugin in docs/index.md - https://github.com/Smirl/steampipe-plugin-cortex/blob/v1.0.0/docs/index.md#cortex--steampipe
