### PR TITLE
Refactor listEntities to be easily testable and add tests

### DIFF
--- a/cortex/table_entity_test.go
+++ b/cortex/table_entity_test.go
@@ -1,0 +1,107 @@
+package cortex
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"gopkg.in/yaml.v3"
+)
+
+func prepareEntityResponse(t *testing.T, entities []CortexEntityElement, page, totalPages, total int) []byte {
+	t.Helper()
+	response := CortexEntityResponse{
+		Entities:   entities,
+		Page:       page,
+		TotalPages: totalPages,
+		Total:      total,
+	}
+	responseBytes, err := yaml.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal response: %v", err)
+	}
+	return responseBytes
+}
+
+func TestListEntitiesSinglePage(t *testing.T) {
+	g := NewWithT(t)
+	gh := ghttp.NewGHTTPWithGomega(g)
+
+	responseBytes := prepareEntityResponse(t, []CortexEntityElement{{Name: "entity1"}}, 0, 1, 1)
+
+	ctx, server, client := setupTestServerAndClient(t,
+		ghttp.CombineHandlers(
+			gh.VerifyRequest("GET", "/api/v1/catalog"),
+			gh.VerifyHeaderKV("Authorization", "Bearer fake_api_key"),
+			gh.RespondWith(http.StatusOK, responseBytes, nil),
+		),
+	)
+	defer server.Close()
+
+	writer := NewSliceWriter[CortexEntityElement](100)
+
+	err := listEntities(ctx, client, writer, "false", "")
+	g.Expect(err).To(BeNil())
+
+	g.Expect(writer.Items).To(HaveLen(1))
+	g.Expect(writer.Items[0].Name).To(Equal("entity1"))
+}
+
+func TestListEntitiesMultiPage(t *testing.T) {
+	g := NewWithT(t)
+	gh := ghttp.NewGHTTPWithGomega(g)
+
+	respPage0Bytes := prepareEntityResponse(t, []CortexEntityElement{
+		{Name: "entity1"},
+		{Name: "entity2"},
+	}, 0, 2, 3)
+
+	respPage1Bytes := prepareEntityResponse(t, []CortexEntityElement{
+		{Name: "entity3"},
+	}, 1, 2, 3)
+
+	ctx, server, client := setupTestServerAndClient(t,
+		ghttp.CombineHandlers(
+			gh.VerifyRequest("GET", "/api/v1/catalog"),
+			gh.VerifyHeaderKV("Authorization", "Bearer fake_api_key"),
+			gh.RespondWith(http.StatusOK, respPage0Bytes, nil),
+		),
+		ghttp.CombineHandlers(
+			gh.VerifyRequest("GET", "/api/v1/catalog"),
+			gh.VerifyHeaderKV("Authorization", "Bearer fake_api_key"),
+			gh.RespondWith(http.StatusOK, respPage1Bytes, nil),
+		),
+	)
+	defer server.Close()
+
+	writer := NewSliceWriter[CortexEntityElement](100)
+
+	err := listEntities(ctx, client, writer, "false", "")
+	g.Expect(err).To(BeNil())
+
+	g.Expect(writer.Items).To(HaveLen(3))
+	g.Expect(writer.Items[0].Name).To(Equal("entity1"))
+	g.Expect(writer.Items[1].Name).To(Equal("entity2"))
+	g.Expect(writer.Items[2].Name).To(Equal("entity3"))
+}
+
+func TestListEntitiesError(t *testing.T) {
+	g := NewWithT(t)
+	gh := ghttp.NewGHTTPWithGomega(g)
+
+	ctx, server, client := setupTestServerAndClient(t,
+		ghttp.CombineHandlers(
+			gh.VerifyRequest("GET", "/api/v1/catalog"),
+			gh.VerifyHeaderKV("Authorization", "Bearer fake_api_key"),
+			gh.RespondWith(http.StatusInternalServerError, "{\"details\": \"fake error on page 0\"}", nil),
+		),
+	)
+	defer server.Close()
+
+	writer := NewSliceWriter[CortexEntityElement](100)
+
+	err := listEntities(ctx, client, writer, "false", "")
+	g.Expect(err).ToNot(BeNil())
+	g.Expect(err.Error()).To(Equal("error from cortex API 500 Internal Server Error: {\"details\": \"fake error on page 0\"}"))
+}


### PR DESCRIPTION
# Summary

This pull request refactors the `listEntities` function in the `cortex` package to improve maintainability and adds comprehensive unit tests for its functionality. The changes include splitting the function into smaller components, introducing error handling for HTTP responses, and adding test cases to ensure correctness.

### Refactoring and Enhancements:
* Renamed `listEntities` to `listEntitiesHydrator` and extracted core logic into a new `listEntities` function for better separation of concerns. [[1]](diffhunk://#diff-0dbf9599ae36ba58bb56a3e995cedb67eed7c57d488a6f494d7605b0391ebed8L84-R86) [[2]](diffhunk://#diff-0dbf9599ae36ba58bb56a3e995cedb67eed7c57d488a6f494d7605b0391ebed8L109-R140)
* Introduced a `HydratorWriter` abstraction to handle data streaming, replacing direct calls to `d.StreamListItem`. [[1]](diffhunk://#diff-0dbf9599ae36ba58bb56a3e995cedb67eed7c57d488a6f494d7605b0391ebed8L109-R140) [[2]](diffhunk://#diff-0dbf9599ae36ba58bb56a3e995cedb67eed7c57d488a6f494d7605b0391ebed8L147-R187)
* Added error handling for HTTP response status and unmarshaling errors in the `listEntities` function.

### Testing:
* Created a new test file `cortex/table_entity_test.go` with the following tests:
  - [`TestListEntitiesSinglePage`](diffhunk://#diff-8c8c75aee87778364e1b31f2f0f9c0e6f59803d25e20f7a216475b3b830f29a6R1-R107): Verifies correct handling of a single-page response.
  - [`TestListEntitiesMultiPage`](diffhunk://#diff-8c8c75aee87778364e1b31f2f0f9c0e6f59803d25e20f7a216475b3b830f29a6R1-R107): Validates pagination logic across multiple pages.
  - [`TestListEntitiesError`](diffhunk://#diff-8c8c75aee87778364e1b31f2f0f9c0e6f59803d25e20f7a216475b3b830f29a6R1-R107): Ensures proper error handling for HTTP errors. 

### Dependency Updates:
* Added the `github.com/imroc/req/v3` package for HTTP client functionality.