### PR TITLE
Add workflow permissions for release drafter

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

This pull request updates the GitHub Actions workflow to include additional permissions for the workflow jobs.

Workflow updates:

* [`.github/workflows/main.yaml`](diffhunk://#diff-71cabc4177e41ea8f15a89eb65398fa8187739f68a2762706d84885cd8b2ddc3R11-R14): Added `permissions` to specify `contents: write` and `pull-requests: read` permissions for the workflow.