### PR TITLE
Scorecard score tests with coverage reporting

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,6 +29,9 @@ jobs:
 
     - name: Coveralls
       uses: coverallsapp/github-action@v2
+      with:
+        file: coverage.out
+        format: golang
 
     - name: Release Drafter
       uses: release-drafter/release-drafter@v6

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
         go-version-file: go.mod
 
     - name: Run tests
-      run: go test -v -coverprofile cover.out ./...
+      run: go test -v -coverprofile coverage.out ./...
 
     - name: Coveralls
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,10 @@ jobs:
         go-version-file: go.mod
 
     - name: Run tests
-      run: go test ./...
+      run: go test -v -coverprofile cover.out ./...
+
+    - name: Coveralls
+      uses: coverallsapp/github-action@v2
 
     - name: Release Drafter
       uses: release-drafter/release-drafter@v6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 <!-- Ensure this matches docs/index.md -->
 # Cortex + Steampipe
 
+[![Coverage Status](https://coveralls.io/repos/github/Smirl/steampipe-plugin-cortex/badge.svg?branch=master)](https://coveralls.io/github/Smirl/steampipe-plugin-cortex?branch=master)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Build](https://github.com/smirl/steampipe-plugin-cortex/actions/workflows/main.yaml/badge.svg)](https://github.com/Smirl/steampipe-plugin-cortex/actions/workflows/main.yaml)
+
 [Steampipe](https://steampipe.io) is an open-source zero-ETL engine to instantly
 query cloud APIs using SQL.
 

--- a/cortex/table_entity.go
+++ b/cortex/table_entity.go
@@ -163,7 +163,7 @@ func listEntities(ctx context.Context, client *req.Client, writer HydratorWriter
 		// Unmarshal the response and check for unmarshal errors
 		err := resp.Into(&response)
 		if err != nil {
-			logger.Error("listEntities", "Error", err)
+			logger.Error("listEntities", "page", page, "Error", err)
 			return err
 		}
 

--- a/cortex/table_scorecard_score.go
+++ b/cortex/table_scorecard_score.go
@@ -117,13 +117,13 @@ func listScorecardScoresHydrator(ctx context.Context, d *plugin.QueryData, h *pl
 	logger := plugin.Logger(ctx)
 	config := GetConfig(d.Connection)
 	client := CortexHTTPClient(ctx, config)
-	hydratorWriter := QueryDataWriter{d}
+	writer := QueryDataWriter{d}
 	scorecardTag := d.EqualsQuals["scorecard_tag"].GetStringValue()
 	logger.Info("listScorecardScoresHydrator", "scorecardTag", scorecardTag)
-	return nil, listScorecardScores(ctx, client, &hydratorWriter, scorecardTag)
+	return nil, listScorecardScores(ctx, client, &writer, scorecardTag)
 }
 
-func listScorecardScores(ctx context.Context, client *req.Client, writer *QueryDataWriter, scorecardTag string) error {
+func listScorecardScores(ctx context.Context, client *req.Client, writer HydratorWriter, scorecardTag string) error {
 	logger := plugin.Logger(ctx)
 
 	// Get information about the scorecard to enrich the data

--- a/cortex/table_scorecard_score.go
+++ b/cortex/table_scorecard_score.go
@@ -2,8 +2,10 @@ package cortex
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
+	"github.com/imroc/req/v3"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -85,7 +87,7 @@ func tableCortexScorecardScore() *plugin.Table {
 		Name:        "cortex_scorecard_score",
 		Description: "Cortex scorecard score api.",
 		List: &plugin.ListConfig{
-			Hydrate: listScorecardScores,
+			Hydrate: listScorecardScoresHydrator,
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "scorecard_tag", Require: plugin.Required},
 			},
@@ -111,23 +113,35 @@ func tableCortexScorecardScore() *plugin.Table {
 	}
 }
 
-func listScorecardScores(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func listScorecardScoresHydrator(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	config := GetConfig(d.Connection)
 	client := CortexHTTPClient(ctx, config)
+	hydratorWriter := QueryDataWriter{d}
+	scorecardTag := d.EqualsQuals["scorecard_tag"].GetStringValue()
+	logger.Info("listScorecardScoresHydrator", "scorecardTag", scorecardTag)
+	return nil, listScorecardScores(ctx, client, &hydratorWriter, scorecardTag)
+}
 
-	var scorecardTag string = d.EqualsQuals["scorecard_tag"].GetStringValue()
+func listScorecardScores(ctx context.Context, client *req.Client, writer *QueryDataWriter, scorecardTag string) error {
+	logger := plugin.Logger(ctx)
 
 	// Get information about the scorecard to enrich the data
 	var scorecardResponse CortexScorecardResponse
-	err := client.
+	resp := client.
 		Get("/api/v1/scorecards/{tag}").
 		SetPathParam("tag", scorecardTag).
-		Do(ctx).
-		Into(&scorecardResponse)
+		Do(ctx)
+
+	// Check for HTTP errors
+	if resp.IsErrorState() {
+		logger.Error("listScorecardScores getScorecard", "Status", resp.Status, "Body", resp.String())
+		return fmt.Errorf("error from cortex API %s: %s", resp.Status, resp.String())
+	}
+	err := resp.Into(&scorecardResponse)
 	if err != nil {
-		logger.Error("listScorecardScores", "Error", err)
-		return nil, err
+		logger.Error("listScorecardScores getScorecard", "Error", err)
+		return err
 	}
 	// Make a map of rule identifier to CortexRule
 	rules := make(map[string]*CortexRuleInfo)
@@ -145,18 +159,26 @@ func listScorecardScores(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	var response CortexScorecardScoreResponse
 	var page int = 0
 	for {
-		err := client.
+		resp := client.
 			Get("/api/v1/scorecards/{tag}/scores").
 			SetPathParam("tag", scorecardTag).
 			// Pagination
 			SetQueryParam("pageSize", "1000").
 			SetQueryParam("page", strconv.Itoa(page)).
-			Do(ctx).
-			Into(&response)
-		if err != nil {
-			logger.Error("listScorecardScores", "Error", err)
-			return nil, err
+			Do(ctx)
+
+		// Check for HTTP errors
+		if resp.IsErrorState() {
+			logger.Error("listScorecardScores getScores", "Status", resp.Status, "Body", resp.String())
+			return fmt.Errorf("error from cortex API %s: %s", resp.Status, resp.String())
 		}
+		// Unmarshal the response and check for unmarshal errors
+		err := resp.Into(&response)
+		if err != nil {
+			logger.Error("listScorecardScores getScores", "page", page, "Error", err)
+			return err
+		}
+
 		for _, result := range response.ServiceScores {
 			for _, ruleScore := range result.Score.Rules {
 				// Get the rule info
@@ -173,10 +195,10 @@ func listScorecardScores(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 					RuleInfo:      ruleInfo,
 				}
 				// send the item to steampipe
-				d.StreamListItem(ctx, row)
+				writer.StreamListItem(ctx, row)
 				// Context can be cancelled due to manual cancellation or the limit has been hit
-				if d.RowsRemaining(ctx) == 0 {
-					return nil, nil
+				if writer.RowsRemaining(ctx) == 0 {
+					return nil
 				}
 			}
 		}
@@ -185,5 +207,5 @@ func listScorecardScores(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 			break
 		}
 	}
-	return nil, nil
+	return nil
 }

--- a/cortex/table_scorecard_score_test.go
+++ b/cortex/table_scorecard_score_test.go
@@ -1,0 +1,106 @@
+package cortex
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"gopkg.in/yaml.v3"
+)
+
+func prepareScorecardResponse(t *testing.T, scorecard CortexScorecard) []byte {
+	t.Helper()
+	response := CortexScorecardResponse{
+		Scorecard: scorecard,
+	}
+	responseBytes, err := yaml.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal response: %v", err)
+	}
+	return responseBytes
+}
+
+func prepareScorecardScoresResponse(t *testing.T, scores []*CortexServiceScore, page, totalPages, total int) []byte {
+	t.Helper()
+	response := CortexScorecardScoreResponse{
+		ServiceScores: scores,
+		Page:          page,
+		TotalPages:    totalPages,
+		Total:         total,
+	}
+	responseBytes, err := yaml.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal response: %v", err)
+	}
+	return responseBytes
+}
+
+func TestListScorecardScoresSinglePage(t *testing.T) {
+	g := NewWithT(t)
+	gh := ghttp.NewGHTTPWithGomega(g)
+
+	scorecard := CortexScorecard{
+		Rules: []*CortexRuleInfo{
+			{Identifier: "rule1", Title: "Rule 1", LevelName: "Level 1", Weight: 10},
+		},
+		Levels: []*CortexScorecardLevel{
+			{Level: CortexLevel{Name: "Level 1", Number: 1}},
+		},
+	}
+	scorecardResponseBytes := prepareScorecardResponse(t, scorecard)
+
+	scores := []*CortexServiceScore{
+		{
+			LastEvaluated: "2025-05-02T12:00:00Z",
+			Service:       &CortexEntityElement{Name: "Service 1", Tag: "service1"},
+			Score: &CortexScore{
+				Rules: []*CortexRuleScore{
+					{Identifier: "rule1", Score: 10},
+				},
+			},
+		},
+	}
+	scoresResponseBytes := prepareScorecardScoresResponse(t, scores, 0, 1, 1)
+
+	ctx, server, client := setupTestServerAndClient(t,
+		ghttp.CombineHandlers(
+			gh.VerifyRequest("GET", "/api/v1/scorecards/tag1"),
+			gh.RespondWith(http.StatusOK, scorecardResponseBytes, nil),
+		),
+		ghttp.CombineHandlers(
+			gh.VerifyRequest("GET", "/api/v1/scorecards/tag1/scores"),
+			gh.RespondWith(http.StatusOK, scoresResponseBytes, nil),
+		),
+	)
+	defer server.Close()
+
+	writer := NewSliceWriter[CortexScorecardScoreRow](100)
+
+	err := listScorecardScores(ctx, client, writer, "tag1")
+	g.Expect(err).To(BeNil())
+
+	g.Expect(writer.Items).To(HaveLen(1))
+	g.Expect(writer.Items[0].Service.Name).To(Equal("Service 1"))
+	g.Expect(writer.Items[0].RuleScore.Identifier).To(Equal("rule1"))
+	g.Expect(writer.Items[0].RuleScore.Score).To(Equal(10))
+}
+
+func TestListScorecardScoresError(t *testing.T) {
+	g := NewWithT(t)
+	gh := ghttp.NewGHTTPWithGomega(g)
+
+	ctx, server, client := setupTestServerAndClient(t,
+		ghttp.CombineHandlers(
+			gh.VerifyRequest("GET", "/api/v1/scorecards/tag1"),
+			gh.RespondWith(http.StatusInternalServerError, "{\"details\": \"fake error on scorecard\"}", nil),
+		),
+	)
+	defer server.Close()
+
+	writer := NewSliceWriter[CortexScorecardScoreRow](100)
+
+	err := listScorecardScores(ctx, client, writer, "tag1")
+	g.Expect(err).ToNot(BeNil())
+	g.Expect(err.Error()).To(Equal("error from cortex API 500 Internal Server Error: {\"details\": \"fake error on scorecard\"}"))
+}


### PR DESCRIPTION
# Summary

This pull request introduces several changes to enhance test coverage, improve error handling, and refactor the code for better maintainability. It also updates the documentation and CI workflows to reflect these improvements.

### CI and Documentation Updates:
* Updated `.github/workflows/main.yaml` to include test coverage reporting using Coveralls and added verbose test output with coverage profiling.
* Enhanced `README.md` by adding badges for build status, test coverage, and license information.

### Error Handling Improvements:
* Improved error logging in `listEntities` to include the `page` number for better debugging.
* Enhanced HTTP error handling in `listScorecardScores` to log detailed error messages and return meaningful error responses. [[1]](diffhunk://#diff-79b99180f291e0ea0b130fa13f7da6061d3e14a8445c1bfc067e9cfa8d7aff03L114-R144) [[2]](diffhunk://#diff-79b99180f291e0ea0b130fa13f7da6061d3e14a8445c1bfc067e9cfa8d7aff03L148-R181)

### Code Refactoring:
* Refactored `listScorecardScores` into two functions: `listScorecardScoresHydrator` for Steampipe integration and `listScorecardScores` for core logic. This separation improves readability and testability. [[1]](diffhunk://#diff-79b99180f291e0ea0b130fa13f7da6061d3e14a8445c1bfc067e9cfa8d7aff03L88-R90) [[2]](diffhunk://#diff-79b99180f291e0ea0b130fa13f7da6061d3e14a8445c1bfc067e9cfa8d7aff03L114-R144)
* Replaced direct calls to `d.StreamListItem` and `d.RowsRemaining` with a `HydratorWriter` abstraction, simplifying the code and improving flexibility.

### Testing Enhancements:
* Added a new test file, `cortex/table_scorecard_score_test.go`, with unit tests for `listScorecardScores`, including cases for successful responses and error scenarios.

### Dependency Updates:
* Introduced new dependencies, including `github.com/imroc/req/v3` for HTTP requests and `gopkg.in/yaml.v3` for YAML processing in tests.