### PR TITLE
Fix bug in relationships where parents would be their own children

### DIFF
--- a/cortex/table_team.go
+++ b/cortex/table_team.go
@@ -146,7 +146,7 @@ func getTeamRelationships(ctx context.Context, client *req.Client) (map[string]R
 		child := relationships[edges.Child]
 		parent := relationships[edges.Parent]
 		child.Parents = append(child.Parents, edges.Parent)
-		parent.Children = append(parent.Children, edges.Parent)
+		parent.Children = append(parent.Children, edges.Child)
 		relationships[edges.Child] = child
 		relationships[edges.Parent] = parent
 	}

--- a/cortex/table_team_test.go
+++ b/cortex/table_team_test.go
@@ -56,8 +56,6 @@ func TestListTeamsSinglePage(t *testing.T) {
 	g.Expect(writer.Items[0].Children[0]).To(Equal("child1"))
 	g.Expect(writer.Items[0].Parents).To(HaveLen(1))
 	g.Expect(writer.Items[0].Parents[0]).To(Equal("parent1"))
-	g.Expect(writer.Items[0].Parents).To(HaveLen(1))
-	g.Expect(writer.Items[0].Parents[0]).To(Equal("parent1"))
 }
 
 func TestListTeamsError(t *testing.T) {
@@ -120,7 +118,7 @@ func TestGetTeamRelationshipsSuccess(t *testing.T) {
 	g.Expect(relationships).To(HaveKey("child1"))
 	g.Expect(relationships["child1"].Parents).To(ContainElement("parent1"))
 	g.Expect(relationships).To(HaveKey("parent1"))
-	g.Expect(relationships["parent1"].Children).To(ContainElement("parent1"))
+	g.Expect(relationships["parent1"].Children).To(ContainElement("child1"))
 }
 
 func TestGetTeamRelationshipsHTTPError(t *testing.T) {


### PR DESCRIPTION
# Summary

This pull request fixes a bug in the `getTeamRelationships` function and updates the corresponding unit tests to ensure correctness. The most important changes include correcting the logic for assigning children in the `getTeamRelationships` function and updating test cases to reflect the fixed behavior.

### Bug Fixes:

* [`cortex/table_team.go`](diffhunk://#diff-1d8ec0b27e96133f9de5ae894a0198ecc107e75bd6c5eb6b13144cc5790ca366L149-R149): Fixed the logic in the `getTeamRelationships` function to correctly assign the `edges.Child` to the `parent.Children` list instead of incorrectly assigning `edges.Parent`.

### Test Updates:

* [`cortex/table_team_test.go`](diffhunk://#diff-383cf519bb5b64fba766e4a753b20f361df01ee1ed89f8006e954e1e8196da19L59-L60): Removed redundant assertions in the `TestListTeamsSinglePage` test case to streamline the test.
* [`cortex/table_team_test.go`](diffhunk://#diff-383cf519bb5b64fba766e4a753b20f361df01ee1ed89f8006e954e1e8196da19L123-R121): Updated the `TestGetTeamRelationshipsSuccess` test case to check that the `parent.Children` list now contains the correct `edges.Child` value instead of the incorrect `edges.Parent`.