### PR TITLE
add tests for getconfig

### DIFF
--- a/cortex/plugin_test.go
+++ b/cortex/plugin_test.go
@@ -1,0 +1,40 @@
+package cortex
+
+import (
+	"testing"
+	_ "unsafe"
+
+	. "github.com/onsi/gomega"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+func TestGetConfig(t *testing.T) {
+	g := NewWithT(t)
+	testApiKey := "test_api_key"
+	testBaseURL := "https://test-url.com"
+	connection := &plugin.Connection{
+		Config: SteampipeConfig{
+			ApiKey:  &testApiKey,
+			BaseURL: &testBaseURL,
+		},
+	}
+
+	config := GetConfig(connection)
+
+	g.Expect(*config.ApiKey).To(Equal("test_api_key"))
+	g.Expect(*config.BaseURL).To(Equal("https://test-url.com"))
+}
+
+func TestGetConfigWithEnvVars(t *testing.T) {
+	g := NewWithT(t)
+	connection := &plugin.Connection{
+		Config: SteampipeConfig{},
+	}
+	t.Setenv("CORTEX_API_KEY", "env_api_key")
+	t.Setenv("CORTEX_BASE_URL", "https://env-url.com")
+
+	config := GetConfig(connection)
+
+	g.Expect(*config.ApiKey).To(Equal("env_api_key"))
+	g.Expect(*config.BaseURL).To(Equal("https://env-url.com"))
+}


### PR DESCRIPTION
# Summary

This pull request introduces unit tests for the `GetConfig` function in the `cortex` package to ensure correct behavior when configuration values are provided directly or via environment variables.

### Added unit tests for `GetConfig`:

* [`cortex/plugin_test.go`](diffhunk://#diff-73d01780c2d1eb1766ba645e965efb0bace673fc53436cd462aa6a279e79787aR1-R40): Added the `TestGetConfig` test to verify that `GetConfig` correctly retrieves configuration values from a `plugin.Connection` object.
* [`cortex/plugin_test.go`](diffhunk://#diff-73d01780c2d1eb1766ba645e965efb0bace673fc53436cd462aa6a279e79787aR1-R40): Added the `TestGetConfigWithEnvVars` test to verify that `GetConfig` correctly retrieves configuration values from environment variables when they are set.