### PR TITLE
Change brand colour to match cortex feedback

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 organization: smirl
 category: ["software development"]
 icon_url: "/images/plugins/smirl/cortex.svg"
-brand_color: "#653ee8"
+brand_color: "#7458DB"
 display_name: "Cortex"
 short_name: "cortex"
 description: "Steampipe plugin for Cortex developer portal."


### PR DESCRIPTION
# Summary

This pull request updates the `docs/index.md` file to adjust the branding details for the Cortex plugin.

Branding updates:

* Updated the `brand_color` value to a new shade of purple (`#7458DB`) to reflect updated branding guidelines.