### PR TITLE
Update docs with correct plugin name in config and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,16 @@ drive action to continuously improve software.
 For example:
 
 ```sql
-select tag, owner_teams, metadata -> 'custom_field' from cortex_entity limit 10
+select 
+  tag,
+  repository,
+  owner_teams
+from 
+  cortex_entity 
+where
+  type = 'service'
+limit 
+  10;
 ```
 
 ## Documentation
@@ -36,7 +45,7 @@ steampipe plugin install smirl/cortex
 
 You will need a Cortex API Token to authenticate with the API.
 
-https://docs.cortex.io/docs/api/cortex-api
+https://docs.cortex.io/api/rest
 
 ### Configuration
 
@@ -50,7 +59,7 @@ Environment variables can be used to override these configuration options.
 
 ```hcl
 connection "cortex" {
-    plugin    = "cortex"
+    plugin    = "smirl/cortex"
 
     # API key from cortex.io for your instance
     # If the environment variable CORTEX_API_KEY is defined it will be overriden

--- a/config/cortex.spc
+++ b/config/cortex.spc
@@ -1,5 +1,5 @@
 connection "cortex" {
-    plugin    = "cortex"
+    plugin    = "smirl/cortex"
 
     # API key from cortex.io for your instance
     # If the environment variable CORTEX_API_KEY is defined it will be overriden

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,11 +26,13 @@ For example:
 
 ```sql
 select 
-  tag, 
-  owner_teams, 
-  metadata -> 'custom_field' 
+  tag,
+  repository,
+  owner_teams
 from 
   cortex_entity 
+where
+  type = 'service'
 limit 
   10;
 ```
@@ -53,7 +55,7 @@ steampipe plugin install smirl/cortex
 
 You will need a Cortex API Token to authenticate with the API.
 
-https://docs.cortex.io/docs/api/cortex-api
+https://docs.cortex.io/api/rest
 
 ### Configuration
 
@@ -67,7 +69,7 @@ Environment variables can be used to override these configuration options.
 
 ```hcl
 connection "cortex" {
-    plugin    = "cortex"
+    plugin    = "smirl/cortex"
 
     # API key from cortex.io for your instance
     # If the environment variable CORTEX_API_KEY is defined it will be overriden

--- a/docs/tables/cortex_entity.md
+++ b/docs/tables/cortex_entity.md
@@ -3,6 +3,12 @@
 This table calls the "List entities" API to get the data about each entity. To
 see the descriptor (yaml definition) of an entity use the `descriptor` table.
 
+By default, archived entities will not show. Passing `where archived is true`
+will fetch archived entities.
+
+Limiting to type often makes queries much faster as less can be fetched from the
+API. For example `where type = 'service'`.
+
 ## Examples
 
 ### Get information about a single entity
@@ -41,6 +47,8 @@ select
   metadata -> 'my_key' as my_key
 from
   cortex_entity 
+where
+  type = 'service'
 limit 
   10;
 ```


### PR DESCRIPTION
This pull request updates query examples, documentation links, and configuration details to improve clarity and align with the latest plugin naming conventions. Additionally, it introduces new guidance on optimizing queries for performance. Below are the most important changes grouped by theme:

### Query and Example Updates:
* Updated SQL query examples in `README.md`, `docs/index.md`, and `docs/tables/cortex_entity.md` to include a `where` clause filtering by `type = 'service'` and added the `repository` column for more detailed results. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R27) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L30-R35) [[3]](diffhunk://#diff-031cfec2423352617b39028487d596ff0f39ac9bbceb61706878b3e31a3134c9R50-R51)

### Documentation Improvements:
* Changed outdated API documentation link from `https://docs.cortex.io/docs/api/cortex-api` to `https://docs.cortex.io/api/rest` in `README.md` and `docs/index.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R48) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L56-R58)
* Added notes in `docs/tables/cortex_entity.md` about excluding archived entities by default and improving query performance by filtering with `type`.

### Configuration Updates:
* Updated plugin name from `cortex` to `smirl/cortex` in configuration examples in `README.md`, `docs/index.md`, and `config/cortex.spc` for consistency with the latest naming conventions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R62) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L70-R72) [[3]](diffhunk://#diff-5e701b8ae1986c55917e97fb33cb0873079bcd07a4c8d51ce9a5eb55e7fe65eaL2-R2)