### PR TITLE
Fix capitalization in organization name and update image paths; refine documentation examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
 ---
-organization: smirl
+organization: Smirl
 category: ["software development"]
-icon_url: "/images/plugins/smirl/cortex.svg"
+icon_url: "/images/plugins/Smirl/cortex.svg"
 brand_color: "#7458DB"
 display_name: "Cortex"
 short_name: "cortex"
 description: "Steampipe plugin for Cortex developer portal."
 og_description: "The Internal Developer Portal eliminating “developer tax” with paved paths to production"
-og_image: "/images/plugins/smirl/cortex-social-graphic.png"
+og_image: "/images/plugins/Smirl/cortex-social-graphic.png"
 engines: ["steampipe", "sqlite", "postgres", "export"]
 ---
 
@@ -83,4 +83,4 @@ connection "cortex" {
 
 ## Get Involved
 
-Open source: https://github.com/smirl/steampipe-plugin-cortex
+Open source: https://github.com/Smirl/steampipe-plugin-cortex

--- a/docs/tables/cortex_scorecard_score.md
+++ b/docs/tables/cortex_scorecard_score.md
@@ -1,9 +1,8 @@
 # Scorecard Scores Table
 
-## Description
-Description of the Scorecard Scores table.
+This table calls the List Scorecard API to get the data about each score. 
 
-## SQL Examples
+## Examples
 
 ### Query scores for a specific scorecard
 


### PR DESCRIPTION
This pull request makes updates to the documentation files to improve consistency in branding and clarity in descriptions. The changes primarily involve standardizing the capitalization of the organization name, updating image paths, and enhancing table descriptions.

### Branding and consistency updates:
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L2-R10): Standardized the capitalization of the organization name from `smirl` to `Smirl` and updated associated paths for `icon_url` and `og_image`.
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L86-R86): Updated the GitHub link to reflect the corrected capitalization in the organization name.

### Clarity improvements:
* [`docs/tables/cortex_scorecard_score.md`](diffhunk://#diff-83e0dc88015fd1e14f131ba9957ac6bd979edf558f577a7b91f161d2b134d97bL3-R5): Replaced the placeholder description of the Scorecard Scores table with a more specific explanation about its functionality, and renamed the "SQL Examples" section to "Examples" for broader applicability.