### PR TITLE
Fix doc titles

### DIFF
--- a/docs/tables/cortex_descriptor.md
+++ b/docs/tables/cortex_descriptor.md
@@ -1,4 +1,4 @@
-# Cortex Entity Table
+# Cortex Descriptor Table
 
 This table calls the List entity descriptors API to get the data about each
 entity descriptor (yaml definition). To see information about the entity from

--- a/docs/tables/cortex_scorecard_score.md
+++ b/docs/tables/cortex_scorecard_score.md
@@ -1,4 +1,4 @@
-# Scorecard Scores Table
+# Cortex Scorecard Scores Table
 
 This table calls the List Scorecard API to get the data about each score. 
 


### PR DESCRIPTION
# Summary

This pull request updates the titles of documentation files to improve clarity and consistency. The changes ensure that table names in the documentation align with their respective APIs.

Documentation updates:

* [`docs/tables/cortex_descriptor.md`](diffhunk://#diff-797317de1760d14c96822f1b49af866a5e07503023e75cb5a29a0551f2d8bd7cL1-R1): Updated the title from "Cortex Entity Table" to "Cortex Descriptor Table" for better alignment with the API it describes.
* [`docs/tables/cortex_scorecard_score.md`](diffhunk://#diff-83e0dc88015fd1e14f131ba9957ac6bd979edf558f577a7b91f161d2b134d97bL1-R1): Updated the title from "Scorecard Scores Table" to "Cortex Scorecard Scores Table" to enhance clarity and consistency.