### PR TITLE
Add error field to CortexRuleScore and expose rule_error column in ta…

### DIFF
--- a/cortex/table_cortex_scorecard_score.go
+++ b/cortex/table_cortex_scorecard_score.go
@@ -63,9 +63,10 @@ type CortexScore struct {
 }
 
 type CortexRuleScore struct {
-	Expression string `yaml:"expression"`
-	Identifier string `yaml:"identifier"`
-	Score      int    `yaml:"score"`
+	Expression string  `yaml:"expression"`
+	Identifier string  `yaml:"identifier"`
+	Score      int     `yaml:"score"`
+	Error      *string `yaml:"error"`
 }
 
 // Used to represent the data we want to return in the table
@@ -108,6 +109,7 @@ func tableCortexScorecardScore() *plugin.Table {
 			{Name: "rule_level_number", Type: proto.ColumnType_INT, Description: "Rule level number.", Transform: transform.FromField("RuleInfo.LevelNumber")},
 			{Name: "rule_weight", Type: proto.ColumnType_INT, Description: "Rule weight.", Transform: transform.FromField("RuleInfo.Weight")},
 			{Name: "rule_score", Type: proto.ColumnType_INT, Description: "Rule score.", Transform: transform.FromField("RuleScore.Score")},
+			{Name: "rule_error", Type: proto.ColumnType_STRING, Description: "Rule error.", Transform: transform.FromField("RuleScore.Error")},
 			{Name: "rule_pass", Type: proto.ColumnType_BOOL, Description: "Rule pass.", Transform: transform.FromP(transform.MethodValue, "IsRulePass")},
 		},
 	}


### PR DESCRIPTION
# Summary

This pull request adds support for capturing and exposing rule errors in the Cortex scorecard score table. The main change is the addition of an `Error` field to the `CortexRuleScore` struct and the corresponding new column in the table schema.

Enhancements to error reporting:

* Added an optional `Error` field to the `CortexRuleScore` struct to store error messages related to rule evaluation.
* Introduced a new `rule_error` column in the Cortex scorecard score table to expose the error information, with transformation mapping from the new struct field.